### PR TITLE
Muliggjøre bruk av kvitteringer i unittesting

### DIFF
--- a/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/Feilmelding.cs
+++ b/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/Feilmelding.cs
@@ -28,12 +28,12 @@ namespace SikkerDigitalPost.Domene.Entiteter.Kvitteringer
         /// <summary>
         /// Beskriver hvor feilen ligger. Enten Klient eller Server.
         /// </summary>
-        public Feiltype Skyldig { get; private set; }
+        public Feiltype Skyldig { get; protected set; }
 
-        public string Detaljer { get; private set; }
+        public string Detaljer { get; protected set; }
 
-        public DateTime TidspunktFeilet { get; private set; }
-
+        public DateTime TidspunktFeilet { get; protected set; }
+        public Feilmelding() { }
         internal Feilmelding(XmlDocument xmlDocument, XmlNamespaceManager namespaceManager):base(xmlDocument,namespaceManager)
         {
             try

--- a/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/Forretningskvittering.cs
+++ b/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/Forretningskvittering.cs
@@ -34,17 +34,17 @@ namespace SikkerDigitalPost.Domene.Entiteter.Kvitteringer
         /// <summary>
         /// Identifiserer en melding og tilhørende kvitteringer unikt.
         /// </summary>
-        public Guid KonversasjonsId { get; private set; }
+        public Guid KonversasjonsId { get; protected set; }
 
         /// <summary>
         /// Unik identifikator for kvitteringen.
         /// </summary>
-        public string MeldingsId { get; private set; }
+        public string MeldingsId { get; protected set; }
 
         /// <summary>
         /// Refereranse til en annen relatert melding. Refererer til den relaterte meldingens MessageId.
         /// </summary>
-        public string RefToMessageId { get; private set; }
+        public string RefToMessageId { get; protected set; }
 
         internal XmlNode BodyReference { get; set; }
 
@@ -58,6 +58,7 @@ namespace SikkerDigitalPost.Domene.Entiteter.Kvitteringer
         /// </summary>
         public override abstract string ToString();
 
+        protected Forretningskvittering() { }
         protected Forretningskvittering(XmlDocument document, XmlNamespaceManager namespaceManager)
         {
             try

--- a/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/LeveringsKvittering.cs
+++ b/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/LeveringsKvittering.cs
@@ -24,6 +24,7 @@ namespace SikkerDigitalPost.Domene.Entiteter.Kvitteringer
     /// </summary>
     public class Leveringskvittering : Forretningskvittering
     {
+        public Leveringskvittering() { }
         internal Leveringskvittering(XmlDocument xmlDocument, XmlNamespaceManager namespaceManager) : base(xmlDocument,namespaceManager)
         {
         }

--- a/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/TransportFeiletKvittering.cs
+++ b/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/TransportFeiletKvittering.cs
@@ -27,33 +27,37 @@ namespace SikkerDigitalPost.Domene.Entiteter.Kvitteringer
         /// <summary>
         /// Spesifikk feilkode for transporten.
         /// </summary>
-        public string Feilkode { get; private set; }
+        public string Feilkode { get; protected set; }
 
         /// <summary>
         /// Kategori/id for hvilken feil som oppstod.
         /// </summary>
-        public string Kategori { get; private set; }
+        public string Kategori { get; protected set; }
 
         /// <summary>
         /// Opprinnelse for feilmeldingen.
         /// </summary>
-        public string Opprinnelse { get; private set; }
+        public string Opprinnelse { get; protected set; }
 
         /// <summary>
         /// Hvor alvorlig er feilen som oppstod
         /// </summary>
-        public string Alvorlighetsgrad { get; private set; }
+        public string Alvorlighetsgrad { get; protected set; }
 
         /// <summary>
         /// En mer detaljert beskrivelse av hva som gikk galt.
         /// </summary>
-        public string Beskrivelse { get; private set; }
+        public string Beskrivelse { get; protected set; }
 
         /// <summary>
         /// Hvem man antar har skyld i feilen.
         /// </summary>
-        public Feiltype Skyldig { get; private set; }
-        
+        public Feiltype Skyldig { get; protected set; }
+
+        public TransportFeiletKvittering()
+        {
+        }
+
         internal TransportFeiletKvittering(XmlDocument document, XmlNamespaceManager namespaceManager) : base(document, namespaceManager)
         {
             try{

--- a/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/TransportOkKvittering.cs
+++ b/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/TransportOkKvittering.cs
@@ -22,6 +22,8 @@ namespace SikkerDigitalPost.Domene.Entiteter.Kvitteringer
     /// </summary>
     public class TransportOkKvittering : Transportkvittering
     {
+        public TransportOkKvittering()
+        { }
         public TransportOkKvittering(XmlDocument document, XmlNamespaceManager namespaceManager) : base(document, namespaceManager)
         {
         }

--- a/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/Transportkvittering.cs
+++ b/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/Transportkvittering.cs
@@ -50,6 +50,8 @@ namespace SikkerDigitalPost.Domene.Entiteter.Kvitteringer
         /// Alle subklasser skal ha en ToString() som beskriver kvitteringen.
         /// </summary>
         public abstract override string ToString();
+        protected Transportkvittering()
+        { }
 
         protected Transportkvittering(XmlDocument document, XmlNamespaceManager namespaceManager)
         {

--- a/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/VarslingFeiletKvittering.cs
+++ b/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/VarslingFeiletKvittering.cs
@@ -28,13 +28,13 @@ namespace SikkerDigitalPost.Domene.Entiteter.Kvitteringer
         /// <summary>
         /// Kanal for varsling til eier av postkasse. Varsling og påminnelsesmeldinger skal sendes på den kanal som blir spesifisert. Kanalen SMS er priset.
         /// </summary>
-        public Varslingskanal Varslingskanal { get; private set; }
+        public Varslingskanal Varslingskanal { get; protected set; }
 
         /// <summary>
         /// Beskrivelse av varsling feilet.
         /// </summary>
-        public string Beskrivelse { get; private set; }
-
+        public string Beskrivelse { get; protected set; }
+        public VarslingFeiletKvittering() { }
         internal VarslingFeiletKvittering(XmlDocument document, XmlNamespaceManager namespaceManager) : base(document, namespaceManager)
         {
             try

--- a/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/Åpningskvittering.cs
+++ b/SikkerDigitalPost.Domene/Entiteter/Kvitteringer/Åpningskvittering.cs
@@ -27,8 +27,8 @@ namespace SikkerDigitalPost.Domene.Entiteter.Kvitteringer
         /// <summary>
         /// Tidspunkt for når borger åpnet posten i sin postkasse.
         /// </summary>
-        public DateTime Åpningstidspunkt { get; private set; }
-
+        public DateTime Åpningstidspunkt { get; protected set; }
+        public Åpningskvittering() { }
         internal Åpningskvittering(XmlDocument xmlDocument, XmlNamespaceManager namespaceManager):base(xmlDocument,namespaceManager)
         {
             try


### PR DESCRIPTION
Kunne bruke kvitteringene i forbindelse med unittesting uten å måtte ha komplette xml-responser og namespacemanager som grunnlag

Lagt inn public constructors som ikke krever xmldoc og namespacemanager.
Endret en del properties fra privat set til protected set
