### PR TITLE
U vedleggsfiks

### DIFF
--- a/SikkerDigitalPost.Domene/Entiteter/Post/Dokumentpakke.cs
+++ b/SikkerDigitalPost.Domene/Entiteter/Post/Dokumentpakke.cs
@@ -56,10 +56,11 @@ namespace SikkerDigitalPost.Domene.Entiteter.Post
             {
                 var dokument = dokumenter.ElementAt(i);
 
-                var likeVedlegg = Vedlegg.Where(v => v.Filnavn == dokument.Filnavn);
-                if (likeVedlegg.Any())
+                var likeFiler = Vedlegg.Any(v => dokument.Filnavn == v.Filnavn) || dokument.Filnavn == Hoveddokument.Filnavn;
+                
+                if (likeFiler)
                 {
-                    throw new KonfigurasjonsException(string.Format("Dokumentet {0} som du prøver å legge til, eksisterer allerede med samme filnavn. Det er ikke tillatt å sende to med samme filnavn.", dokument.Filnavn));
+                    throw new KonfigurasjonsException(string.Format("Dokumentet {0} som du prøver å legge til, eksisterer allerede med samme filnavn. Det er ikke tillatt å ha likt filnavn på to vedlegg, eller vedlegg med samme filnavn som hoveddokument.", dokument.Filnavn));
                 }
 
                 if (dokument.Bytes.Length == 0)

--- a/SikkerDigitalPost.Domene/Entiteter/Post/Dokumentpakke.cs
+++ b/SikkerDigitalPost.Domene/Entiteter/Post/Dokumentpakke.cs
@@ -55,6 +55,13 @@ namespace SikkerDigitalPost.Domene.Entiteter.Post
             for (int i = 0; i < dokumenter.Count(); i++)
             {
                 var dokument = dokumenter.ElementAt(i);
+
+                var likeVedlegg = Vedlegg.Where(v => v.Filnavn == dokument.Filnavn);
+                if (likeVedlegg.Any())
+                {
+                    throw new KonfigurasjonsException(string.Format("Dokumentet {0} som du prøver å legge til, eksisterer allerede med samme filnavn. Det er ikke tillatt å sende to med samme filnavn.", dokument.Filnavn));
+                }
+
                 if (dokument.Bytes.Length == 0)
                     throw new KonfigurasjonsException(string.Format("Dokumentet {0} som du prøver å legge til som vedlegg er tomt. Det er ikke tillatt å sende tomme dokumenter.", dokument.Filnavn));
                 dokument.Id = string.Format("Id_{0}", i + 3 + startId);

--- a/SikkerDigitalPost.Tester/ArkivTester.cs
+++ b/SikkerDigitalPost.Tester/ArkivTester.cs
@@ -12,15 +12,14 @@
  * limitations under the License.
  */
 
-using System;
 using System.IO;
 using System.IO.Compression;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SikkerDigitalPost.Domene.Entiteter.Aktører;
-using SikkerDigitalPost.Klient.AsicE;
 using SikkerDigitalPost.Domene.Entiteter.Post;
+using SikkerDigitalPost.Domene.Exceptions;
+using SikkerDigitalPost.Klient.AsicE;
 
 namespace SikkerDigitalPost.Tester
 {
@@ -57,6 +56,14 @@ namespace SikkerDigitalPost.Tester
                 var vedlegg = Dokumentpakke.Vedlegg[i];
                 Assert.AreEqual(vedlegg.Id, "Id_" + (i + 3));
             }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(KonfigurasjonsException), "To like filer ble uriktig godtatt i dokumentpakken.")]
+        public void LeggTilDokumenterMedSammeFilnavnKasterException()
+        {
+            Dokumentpakke.LeggTilVedlegg(new Dokument("Dokument 1", new byte[] { 0x00 }, "text/plain", "NO", "Filnavn.txt"));
+            Dokumentpakke.LeggTilVedlegg(new Dokument("Dokument 2", new byte[] { 0x00 }, "text/plain", "NO", "Filnavn.txt"));   
         }
 
         [TestMethod]

--- a/SikkerDigitalPost.Tester/ArkivTester.cs
+++ b/SikkerDigitalPost.Tester/ArkivTester.cs
@@ -60,11 +60,19 @@ namespace SikkerDigitalPost.Tester
 
         [TestMethod]
         [ExpectedException(typeof(KonfigurasjonsException), "To like filer ble uriktig godtatt i dokumentpakken.")]
-        public void LeggTilDokumenterMedSammeFilnavnKasterException()
+        public void LeggTilVedleggSammeFilnavnKasterException()
         {
-            Dokumentpakke.LeggTilVedlegg(new Dokument("Dokument 1", new byte[] { 0x00 }, "text/plain", "NO", "Filnavn.txt"));
-            Dokumentpakke.LeggTilVedlegg(new Dokument("Dokument 2", new byte[] { 0x00 }, "text/plain", "NO", "Filnavn.txt"));   
+            Dokumentpakke.LeggTilVedlegg(new Dokument("DokumentUnikt", new byte[] { 0x00 }, "text/plain", "NO", "Filnavn.txt"));
+            Dokumentpakke.LeggTilVedlegg(new Dokument("DokumentDuplikat", new byte[] { 0x00 }, "text/plain", "NO", "Filnavn.txt"));   
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(KonfigurasjonsException), "To like filer ble uriktig godtatt i dokumentpakken.")]
+        public void LeggTilVedleggSammeNavnSomHoveddokumentKasterException()
+        {
+            Dokumentpakke.LeggTilVedlegg(new Dokument("DokumentSomHoveddokument", new byte[] { 0x00 }, "text/plain", "NO", Hoveddokument.Filnavn));
+        }
+
 
         [TestMethod]
         public void LagArkivOgVerifiserDokumentInnhold()

--- a/SikkerDigitalPost.Testklient/Program.cs
+++ b/SikkerDigitalPost.Testklient/Program.cs
@@ -52,8 +52,8 @@ namespace SikkerDigitalPost.Testklient
 
             //Forsendelse
             string mpcId = "hest";
-            var dokumentpakke = new Dokumentpakke(new Dokument("Tirsdagstest", hoveddokumentsti, "text/plain", "NO", "Hoveddokumentæ"));
-            dokumentpakke.LeggTilVedlegg(new Dokument("Vedlegg", vedleggsti, "text/plain", "NO", "253014_1_P.docx1.pdf"));
+            var dokumentpakke = new Dokumentpakke(new Dokument("Tirsdagstest", hoveddokumentsti, "text/plain", "NO", "Hoveddokument.txt"));
+            dokumentpakke.LeggTilVedlegg(new Dokument("Vedlegg", vedleggsti, "text/plain", "NO", "Vedlegg.txt"));
             var forsendelse = new Forsendelse(behandlingsansvarlig, digitalPost, dokumentpakke, Prioritet.Prioritert, mpcId, "NO");
 
             //Send

--- a/SikkerDigitalPost.Testklient/Program.cs
+++ b/SikkerDigitalPost.Testklient/Program.cs
@@ -34,7 +34,7 @@ namespace SikkerDigitalPost.Testklient
               * Posten som er teknisk avsender, og det er Digipostkassen som skal motta meldingen. 
               */
 
-            Postkasseinnstillinger postkasseinnstillinger = Postkasseinnstillinger.GetPosten();
+            PostkasseInnstillinger postkasseinnstillinger = PostkasseInnstillinger.GetPosten();
 
             //Avsender
             var behandlingsansvarlig = new Behandlingsansvarlig(new Organisasjonsnummer(postkasseinnstillinger.OrgNummerBehandlingsansvarlig));


### PR DESCRIPTION
Nå vil vi kaste exception i det øyeblikket vi prøver å sende filer som allerede er i Dokumentpakken. Dette gjelder enten det er vedlegg eller hoveddokument
