### PR TITLE
B avsenderidentifikator

### DIFF
--- a/SikkerDigitalPost.Klient/Envelope/Forretningsmelding/DigitalPostElement.cs
+++ b/SikkerDigitalPost.Klient/Envelope/Forretningsmelding/DigitalPostElement.cs
@@ -53,6 +53,13 @@ namespace SikkerDigitalPost.Klient.Envelope.Forretningsmelding
                 organisasjon.SetAttribute("authority", "iso6523-actorid-upis");
                 organisasjon.InnerText = Settings.Forsendelse.Behandlingsansvarlig.Organisasjonsnummer.Iso6523();
 
+                var avsenderIdentifikator = Settings.Forsendelse.Behandlingsansvarlig.Avsenderidentifikator;
+                if(avsenderIdentifikator != String.Empty){
+                    XmlElement avsenderidentifikator = 
+                        avsender.AppendChildElement("avsenderidentifikator", "ns9", Navnerom.Ns9, Context);
+                    avsenderidentifikator.InnerText = avsenderIdentifikator;
+                }
+
                 XmlElement fakturaReferanse = avsender.AppendChildElement("fakturaReferanse", "ns9", Navnerom.Ns9, Context);
                 fakturaReferanse.InnerText = Settings.Forsendelse.Behandlingsansvarlig.Fakturareferanse;
             }

--- a/SikkerDigitalPost.Testklient/Program.cs
+++ b/SikkerDigitalPost.Testklient/Program.cs
@@ -46,8 +46,9 @@ namespace SikkerDigitalPost.Testklient
                 new Behandlingsansvarlig(new Organisasjonsnummer(postkasseInnstillinger.OrgNummerBehandlingsansvarlig));
             var tekniskAvsender = new Databehandler(postkasseInnstillinger.OrgNummerDatabehandler,
                 postkasseInnstillinger.Avsendersertifikat);
+            behandlingsansvarlig.Avsenderidentifikator = "digipost";
 
-            //MottakerF
+            //Mottaker
             var mottaker = new Mottaker(postkasseInnstillinger.Personnummer, postkasseInnstillinger.Postkasseadresse,
                 postkasseInnstillinger.Mottakersertifikat, postkasseInnstillinger.OrgnummerPostkasse);
 

--- a/VersionInfo.cs
+++ b/VersionInfo.cs
@@ -14,5 +14,5 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("1.01.*")]
-[assembly: AssemblyFileVersion("1.01.*")]
+[assembly: AssemblyVersion("1.1.*")]
+[assembly: AssemblyFileVersion("1.1.*")]


### PR DESCRIPTION
Avsenderidentifikator-element er nå lagt til i xml. Dette elementet ble aldri lagt til i xml, og dette fører til problemer med organisasjoner (f.eks. Posten) hvor det er flere avsenderidentifikatorer. Fikset nå!